### PR TITLE
PR: Add missing `__init__.py` in widgets

### DIFF
--- a/spyder_env_manager/spyder/widgets/__init__.py
+++ b/spyder_env_manager/spyder/widgets/__init__.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+# ----------------------------------------------------------------------------
+# Copyright © 2023, Spyder Development Team and spyder-env-manager contributors
+#
+# Licensed under the terms of the MIT license
+# ----------------------------------------------------------------------------
+"""
+GUI widgets for Spyder env manager.
+"""


### PR DESCRIPTION
As the tittle says. Add missing __init__.py in widgets.