### PR TITLE
PR: Make the plugin work with Spyder prereleases, fix tests and simplify setup on CI

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,24 @@
+codecov:
+  branch: main
+  notify:
+    require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+
+  status:
+    project:
+      default:
+        threshold: 5%
+    patch: no
+    changes: yes
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no

--- a/.github/workflows/linux-tests.yml
+++ b/.github/workflows/linux-tests.yml
@@ -34,30 +34,25 @@ jobs:
           sudo apt-get update --fix-missing
           sudo apt-get install -qq pyqt5-dev-tools libxcb-xinerama0 xterm --fix-missing
       - name: Install Conda
-        uses: conda-incubator/setup-miniconda@v3
+        uses: mamba-org/setup-micromamba@v2
         with:
-           activate-environment: test
-           auto-update-conda: true
-           channels: conda-forge
-           channel-priority: strict
-           auto-activate-base: false
-           python-version: ${{ matrix.PYTHON_VERSION }}
+           environment-name: test
+           create-args: python=${{ matrix.PYTHON_VERSION }}
+           micromamba-version: '1.5.10-0'
       - name: Install package and test dependencies with conda
         if: ${{ startsWith(matrix.USE_CONDA, 'True') }}
         shell: bash -el {0}
         run: |
-            conda install --file requirements/conda.txt -y -q
-            conda install --file requirements/tests.txt -y -q
+            micromamba install --file requirements/main.yml
+            micromamba install --file requirements/tests.yml
+            pip install --no-deps -e .
       - name: Install package and test dependencies with pip
         if: ${{ startsWith(matrix.USE_CONDA, 'False') }}
         shell: bash -el {0}
-        run: |
-            pip install -r requirements/conda.txt
-            pip install -r requirements/tests.txt
+        run: pip install --pre -e .[test]
       - name: Install Spyder from master branch (Future Spyder 6.1)
         shell: bash -el {0}
         run: |
-            conda install pyyaml=6.0 # Prevents error updating PyYAML via pip when installing Spyder from source on Python 3.8
             pip install --no-deps git+https://github.com/spyder-ide/spyder.git@master
             pip install --no-deps git+https://github.com/spyder-ide/spyder-kernels.git@master
       - name: Install envs-manager from its subrepo
@@ -66,14 +61,11 @@ jobs:
             cd external-deps/envs-manager
             pip install -e .
             cd ../..
-      - name: Install Package
-        shell: bash -el {0}
-        run: pip install --no-deps -e .
       - name: Show environment information
         shell: bash -el {0}
         run: |
-          conda info
-          conda list
+          micromamba info
+          micromamba list
       - name: Run tests
         shell: bash -el {0}
         run: xvfb-run --auto-servernum pytest --ignore=./external-deps --color=yes --cov-report xml --cov=spyder_env_manager -x -vv

--- a/external-deps/envs-manager/.gitrepo
+++ b/external-deps/envs-manager/.gitrepo
@@ -4,9 +4,9 @@
 ; git-subrepo command. See https://github.com/ingydotnet/git-subrepo#readme
 ;
 [subrepo]
-	remote = https://github.com/ccordoba12/envs-manager.git
-	branch = fix-channels
-	commit = 633d1dd8c2b3aef531fa966cf69466d46a96ede9
-	parent = af3f9c2f37cc79dfb91f483de6fc177ed698f4a6
+	remote = https://github.com/spyder-ide/envs-manager.git
+	branch = main
+	commit = b5df9bcea2e1c6089234494903d10ac1b839e3c5
+	parent = 11e8944d19f5cdea74d1cc9731fbc2a6443ce58e
 	method = merge
 	cmdver = 0.4.9

--- a/external-deps/envs-manager/.gitrepo
+++ b/external-deps/envs-manager/.gitrepo
@@ -4,9 +4,9 @@
 ; git-subrepo command. See https://github.com/ingydotnet/git-subrepo#readme
 ;
 [subrepo]
-	remote = https://github.com/spyder-ide/envs-manager.git
-	branch = main
-	commit = 1ab367ed06b3f8342ffd68132225b7c792e5ae56
-	parent = 5d5ba23694d2a495d95c1c0d12355b6bca0167a6
+	remote = https://github.com/ccordoba12/envs-manager.git
+	branch = fix-channels
+	commit = 633d1dd8c2b3aef531fa966cf69466d46a96ede9
+	parent = af3f9c2f37cc79dfb91f483de6fc177ed698f4a6
 	method = merge
 	cmdver = 0.4.9

--- a/external-deps/envs-manager/envs_manager/backends/conda_like_interface.py
+++ b/external-deps/envs-manager/envs_manager/backends/conda_like_interface.py
@@ -60,7 +60,8 @@ class CondaLikeInterface(EnvManagerInstance):
         if packages:
             command += packages
         if channels:
-            command += ["-c"] + channels
+            for channel in channels:
+                command += ["-c"] + [channel]
         if force:
             command += ["-y"]
         try:
@@ -162,8 +163,8 @@ class CondaLikeInterface(EnvManagerInstance):
         if force:
             command += ["-y"]
         if channels:
-            channels = ["-c"] + channels
-            command += channels
+            for channel in channels:
+                command += ["-c"] + [channel]
         try:
             result = run_command(command, capture_output=capture_output)
             if capture_output:

--- a/requirements/conda.txt
+++ b/requirements/conda.txt
@@ -1,5 +1,0 @@
-envs-manager>=0.1.3
-qtawesome
-qtpy
-setuptools
-spyder>=6

--- a/requirements/main.yml
+++ b/requirements/main.yml
@@ -1,0 +1,12 @@
+channels:
+  - conda-forge/label/spyder_dev
+  - conda-forge/label/spyder_rc
+  - conda-forge/label/spyder_kernels_dev
+  - conda-forge/label/spyder_kernels_rc
+  - conda-forge
+dependencies:
+  - envs-manager >=0.1.3
+  - qtawesome
+  - qtpy
+  - setuptools
+  - spyder >=6.1.0a1

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,6 +1,0 @@
-check-manifest
-codecov
-pytest
-pytest-cov
-pytest-qt
-recommonmark

--- a/requirements/tests.yml
+++ b/requirements/tests.yml
@@ -1,0 +1,9 @@
+channels:
+  - conda-forge
+dependencies:
+  - check-manifest
+  - codecov
+  - pytest
+  - pytest-cov
+  - pytest-qt
+  - recommonmark

--- a/setup.py
+++ b/setup.py
@@ -25,8 +25,18 @@ setup(
         "envs-manager>=0.1.3",
         "qtpy",
         "qtawesome",
-        "spyder>=6",
+        "spyder>=6.1.0a1",
     ],
+    extras_require={
+        "test": [
+            "check-manifest",
+            "codecov",
+            "pytest",
+            "pytest-cov",
+            "pytest-qt",
+            "recommonmark",
+        ],
+    },
     packages=find_packages(),
     entry_points={
         "spyder.plugins": [

--- a/spyder_env_manager/spyder/widgets/main_widget.py
+++ b/spyder_env_manager/spyder/widgets/main_widget.py
@@ -19,6 +19,7 @@ from string import Template
 # Third party imports
 from envs_manager.backends.conda_like_interface import CondaLikeInterface
 from envs_manager.manager import Manager
+from packaging.version import parse
 import qtawesome as qta
 from qtpy.QtCore import QThread, QUrl, Signal
 from qtpy.QtGui import QColor
@@ -32,6 +33,7 @@ from qtpy.QtWidgets import (
 )
 
 # Spyder and local imports
+from spyder import __version__ as spyder_version
 from spyder.api.translations import get_translation
 from spyder.api.widgets.main_widget import (
     PluginMainWidget,
@@ -589,6 +591,11 @@ class SpyderEnvManagerWidget(PluginMainWidget):
                 manager.install,
                 self._after_package_changed,
                 packages,
+                channels=(
+                    self._prerelease_channels()
+                    if parse(spyder_version).is_prerelease
+                    else None
+                ),
                 force=True,
                 capture_output=True,
             )
@@ -888,6 +895,11 @@ class SpyderEnvManagerWidget(PluginMainWidget):
                 manager.create_environment,
                 self._add_new_environment_entry,
                 packages=packages,
+                channels=(
+                    self._prerelease_channels()
+                    if parse(spyder_version).is_prerelease
+                    else None
+                ),
                 force=True,
             )
         elif dialog and action == SpyderEnvManagerWidgetActions.ImportEnvironment:
@@ -1170,3 +1182,11 @@ class SpyderEnvManagerWidget(PluginMainWidget):
         box.setDefaultButton(QMessageBox.Ok)
         box.setText(message)
         box.exec_()
+
+    def _prerelease_channels(self):
+        """Extra channels to make this plugin work with Spyder prereleases."""
+        return [
+            "conda-forge",
+            "conda-forge/label/spyder_kernels_dev",
+            "conda-forge/label/spyder_kernels_rc",
+        ]

--- a/spyder_env_manager/spyder/widgets/main_widget.py
+++ b/spyder_env_manager/spyder/widgets/main_widget.py
@@ -18,7 +18,7 @@ from string import Template
 
 # Third party imports
 from envs_manager.backends.conda_like_interface import CondaLikeInterface
-from envs_manager.manager import DEFAULT_BACKENDS_ROOT_PATH, Manager
+from envs_manager.manager import Manager
 import qtawesome as qta
 from qtpy.QtCore import QThread, QUrl, Signal
 from qtpy.QtGui import QColor
@@ -43,9 +43,6 @@ from spyder.utils.icon_manager import ima
 from spyder.utils.palette import SpyderPalette
 from spyder.widgets.browser import FrameWebView
 
-from spyder_env_manager.spyder.config import (
-    conda_like_executable,
-)
 from spyder_env_manager.spyder.workers import EnvironmentManagerWorker
 from spyder_env_manager.spyder.widgets.helper_widgets import (
     CustomParametersDialog,
@@ -520,7 +517,7 @@ class SpyderEnvManagerWidget(PluginMainWidget):
         if not environment_path:
             return
         external_executable = self.get_conf("conda_file_executable_path")
-        backend = "conda-like"
+        backend = CondaLikeInterface.ID
         manager = Manager(
             backend,
             env_directory=environment_path,
@@ -790,7 +787,7 @@ class SpyderEnvManagerWidget(PluginMainWidget):
         """
         root_path = Path(self.get_conf("environments_path"))
         external_executable = self.get_conf("conda_file_executable_path")
-        backend = "conda-like"
+        backend = CondaLikeInterface.ID
         package_name = package_info["name"]
         if action == EnvironmentPackagesActions.UpdatePackage:
             env_name = self.select_environment.currentText()
@@ -871,7 +868,7 @@ class SpyderEnvManagerWidget(PluginMainWidget):
         """
         root_path = Path(self.get_conf("environments_path"))
         external_executable = self.get_conf("conda_file_executable_path")
-        backend = "conda-like"
+        backend = CondaLikeInterface.ID
         if dialog and action == SpyderEnvManagerWidgetActions.NewEnvironment:
             backend = dialog.combobox.currentText()
             env_name = dialog.lineedit_string.text()
@@ -985,7 +982,7 @@ class SpyderEnvManagerWidget(PluginMainWidget):
             CustomParametersDialogWidgets.ComboBox,
             CustomParametersDialogWidgets.LineEditFile,
         ]
-        contents = [{"conda-like"}, {}]
+        contents = [{CondaLikeInterface.ID}, {}]
         self._message_box_editable(
             title,
             messages,
@@ -1015,7 +1012,7 @@ class SpyderEnvManagerWidget(PluginMainWidget):
             CustomParametersDialogWidgets.LineEditString,
             CustomParametersDialogWidgets.ComboBoxFile,
         ]
-        contents = [{"conda-like"}, {}, {}]
+        contents = [{CondaLikeInterface.ID}, {}, {}]
         self._message_box_editable(
             title,
             messages,
@@ -1033,7 +1030,7 @@ class SpyderEnvManagerWidget(PluginMainWidget):
             CustomParametersDialogWidgets.ComboBoxEdit,
         ]
         contents = [
-            {"conda-like"},
+            {CondaLikeInterface.ID},
             {},
             ["3.8.16", "3.9.16", "3.10.9", "3.11.0"],
         ]


### PR DESCRIPTION
- Our tests were failing because the plugin couldn't install Spyder-kernels 3.1.0a1, which is now the minimal version required by Spyder 6.1.0a2.
- To fix that, I added the Spyder-kernels prerelease channels to the conda-forge one if we detect Spyder's version is a prerelease.
- Switch to micromamba instead of conda on CI (for some odd reason conda 25 can't resolve the prerelease conda-forge channels).
- Simplify setup on CI by using env yaml files for micromamba and adding an `extra_requires/test` entry for pip.
- Add `codecov.yml` to configure codecov and avoid a failure on PRs due to coverage.
- Depends on https://github.com/spyder-ide/envs-manager/pull/31.