### PR TITLE
PR: Remove option to set a Pixi executable

### DIFF
--- a/.github/workflows/linux-tests.yml
+++ b/.github/workflows/linux-tests.yml
@@ -39,13 +39,6 @@ jobs:
            environment-name: test
            create-args: python=${{ matrix.PYTHON_VERSION }}
            micromamba-version: '1.5.10-0'
-      - name: Install Pixi
-        shell: bash -l {0}
-        run: |
-          # This script installs Pixi in ~/.pixi/bin
-          curl -fsSL https://pixi.sh/install.sh | sh
-          # This is necessary for envs-manager to detect Pixi
-          echo "ENV_BACKEND_EXECUTABLE=$HOME/.pixi/bin/pixi" >> $GITHUB_ENV
       - name: Install package and test dependencies with conda
         if: ${{ startsWith(matrix.USE_CONDA, 'True') }}
         shell: bash -el {0}

--- a/external-deps/envs-manager/.github/workflows/linux-tests.yml
+++ b/external-deps/envs-manager/.github/workflows/linux-tests.yml
@@ -29,16 +29,6 @@ jobs:
            python-version: ${{ matrix.python-version }}
            environment-file: requirements/environment.yml
            auto-activate-base: false
-      - name: Install Micromamba and setup as executable backend
-        shell: bash -l {0}
-        run: |
-          curl -Ls https://micro.mamba.pm/api/micromamba/linux-64/1.5.10 | tar -xvj bin/micromamba
-          echo "ENV_BACKEND_EXECUTABLE=${{ github.workspace }}/bin/micromamba" >> $GITHUB_ENV
-      - name: Install Pixi
-        shell: bash -l {0}
-        run: |
-          # This script installs Pixi in ~/.pixi/bin
-          curl -fsSL https://pixi.sh/install.sh | sh
       - name: Install envs-manager
         shell: bash -l {0}
         run: |

--- a/external-deps/envs-manager/.github/workflows/macos-tests.yml
+++ b/external-deps/envs-manager/.github/workflows/macos-tests.yml
@@ -29,16 +29,6 @@ jobs:
            python-version: ${{ matrix.python-version }}
            environment-file: requirements/environment.yml
            auto-activate-base: false
-      - name: Install Micromamba and setup as executable backend
-        shell: bash -l {0}
-        run: |
-          curl -Ls https://micro.mamba.pm/api/micromamba/osx-64/1.5.10 | tar -xvj bin/micromamba
-          echo "ENV_BACKEND_EXECUTABLE=${{ github.workspace }}/bin/micromamba" >> $GITHUB_ENV
-      - name: Install Pixi
-        shell: bash -l {0}
-        run: |
-          # This script installs Pixi in ~/.pixi/bin
-          curl -fsSL https://pixi.sh/install.sh | sh
       - name: Install envs-manager
         shell: bash -l {0}
         run: |

--- a/external-deps/envs-manager/.github/workflows/windows-tests.yml
+++ b/external-deps/envs-manager/.github/workflows/windows-tests.yml
@@ -29,18 +29,6 @@ jobs:
            python-version: ${{ matrix.python-version }}
            environment-file: requirements/environment.yml
            auto-activate-base: false
-      - name: Install Micromamba and setup as executable backend
-        shell: bash -l {0}
-        run: |
-          mkdir micromamba
-          curl -Ls https://micro.mamba.pm/api/micromamba/win-64/1.5.10 | tar -xvj -C micromamba
-          echo "ENV_BACKEND_EXECUTABLE=${{ github.workspace }}\micromamba\Library\bin\micromamba.exe" >> $GITHUB_ENV
-          echo "MAMBA_ROOT_PREFIX=${{ github.workspace }}\micromamba" >> $GITHUB_ENV
-      - name: Install Pixi
-        shell: bash -l {0}
-        run: |
-          # This script installs Pixi in ~/.pixi/bin
-          curl -fsSL https://pixi.sh/install.sh | sh
       - name: Install envs-manager
         shell: bash -l {0}
         run: |

--- a/external-deps/envs-manager/.gitrepo
+++ b/external-deps/envs-manager/.gitrepo
@@ -4,9 +4,9 @@
 ; git-subrepo command. See https://github.com/ingydotnet/git-subrepo#readme
 ;
 [subrepo]
-	remote = https://github.com/spyder-ide/env-manager.git
-	branch = main
-	commit = ca869c2606e09a598bdea54523b6f27c2c1019a6
-	parent = 04f164242dda68164eab3072708eb9931b1da552
+	remote = https://github.com/ccordoba12/envs-manager.git
+	branch = download-exec
+	commit = 1038742818f791248adbf682529ab2ef23e234c1
+	parent = e61abd69a776795ce08f520cf65f6250e29d48cb
 	method = merge
 	cmdver = 0.4.9

--- a/external-deps/envs-manager/.gitrepo
+++ b/external-deps/envs-manager/.gitrepo
@@ -4,9 +4,9 @@
 ; git-subrepo command. See https://github.com/ingydotnet/git-subrepo#readme
 ;
 [subrepo]
-	remote = https://github.com/ccordoba12/envs-manager.git
-	branch = download-exec
-	commit = 1038742818f791248adbf682529ab2ef23e234c1
-	parent = e61abd69a776795ce08f520cf65f6250e29d48cb
+	remote = https://github.com/spyder-ide/envs-manager.git
+	branch = main
+	commit = 4a39ffb75ef86a77fb3edeb086074655f650e02b
+	parent = 0ff6c95ab1b65e285ecfcd2d413593b3e8b5fc80
 	method = merge
 	cmdver = 0.4.9

--- a/external-deps/envs-manager/envs_manager/backends/api.py
+++ b/external-deps/envs-manager/envs_manager/backends/api.py
@@ -3,6 +3,8 @@
 # SPDX-License-Identifier: MIT
 
 from __future__ import annotations
+
+from pathlib import Path
 import subprocess
 from typing import TypedDict
 
@@ -100,11 +102,12 @@ class BackendInstance:
         self,
         environment_path: str,
         envs_directory: str,
-        external_executable: str | None = None,
+        bin_directory: str,
     ):
         self.environment_path = environment_path
         self.envs_directory = envs_directory
-        self.external_executable = external_executable
+        self.bin_directory = bin_directory
+        self.external_executable = None
         self.executable_variant = None
         assert self.validate(), f"{self.ID} backend unavailable!"
 
@@ -114,6 +117,20 @@ class BackendInstance:
 
     def validate(self) -> bool:
         pass
+
+    def find_backend_executable(self, exec_name: str):
+        """Return the backend executable in bin_directory, if available."""
+        cmd_list = [exec_name, f"{exec_name}.exe"]
+        for cmd in cmd_list:
+            path = Path(self.bin_directory) / cmd
+            if path.exists():
+                return str(path)
+
+        return
+
+    def install_backend_executable(self):
+        """Install the backend executable in bin_directory."""
+        raise NotImplementedError
 
     def create_environment(
         self,

--- a/external-deps/envs-manager/envs_manager/cli.py
+++ b/external-deps/envs-manager/envs_manager/cli.py
@@ -6,12 +6,7 @@ import argparse
 import logging
 import sys
 
-from envs_manager.manager import (
-    DEFAULT_BACKENDS_ROOT_PATH,
-    DEFAULT_BACKEND,
-    EXTERNAL_EXECUTABLE,
-    Manager,
-)
+from envs_manager.manager import DEFAULT_BACKENDS_ROOT_PATH, DEFAULT_BACKEND, Manager
 
 
 def main(args=None):
@@ -167,14 +162,12 @@ def main(args=None):
     logger.debug(options)
     logger.debug(f"Using BACKENDS_ROOT_PATH: {DEFAULT_BACKENDS_ROOT_PATH}")
     logger.debug(f"Using ENV_BACKEND: {options.backend}")
-    logger.debug(f"Using ENV_BACKEND_EXECUTABLE: {EXTERNAL_EXECUTABLE}")
 
     if options.env_name:
         manager = Manager(
             backend=options.backend,
             env_name=options.env_name,
             root_path=DEFAULT_BACKENDS_ROOT_PATH,
-            external_executable=EXTERNAL_EXECUTABLE,
         )
         if options.command == "create":
             manager.create_environment(
@@ -205,5 +198,5 @@ def main(args=None):
         else:
             backend = DEFAULT_BACKEND
 
-        manager = Manager(backend=backend, external_executable=EXTERNAL_EXECUTABLE)
+        manager = Manager(backend=backend)
         manager.list_environments()

--- a/external-deps/envs-manager/envs_manager/tests/test_cli.py
+++ b/external-deps/envs-manager/envs_manager/tests/test_cli.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: MIT
 
 import os
-from pathlib import Path
 import subprocess
 
 import pytest
@@ -69,19 +68,12 @@ def test_cli(tmp_path, backend):
     backends_root_path.mkdir(parents=True)
     os.environ["BACKENDS_ROOT_PATH"] = str(backends_root_path)
 
-    env = os.environ.copy()
-    if backend_value == "pixi":
-        env["ENV_BACKEND_EXECUTABLE"] = str(
-            Path(env.get("HOME")) / ".pixi" / "bin" / "pixi"
-        )
-
     # Check environment creation
     create_output = subprocess.check_output(
         " ".join(
             ["envs-manager", f"-b={backend_value}", f"-e={list_env_result}", "create"]
         ),
         shell=True,
-        env=env,
     )
     assert any(
         [
@@ -101,7 +93,6 @@ def test_cli(tmp_path, backend):
             ]
         ),
         shell=True,
-        env=env,
     )
     assert f"Using ENV_BACKEND: {backend_value}" not in str(list_env_output)
     assert list_env_result in str(list_env_output)
@@ -118,7 +109,6 @@ def test_cli(tmp_path, backend):
             ]
         ),
         shell=True,
-        env=env,
     )
     assert f"Using ENV_BACKEND: {backend_value}" in str(list_env_packages)
     assert package_list_env_result in str(list_env_packages)

--- a/external-deps/envs-manager/envs_manager/tests/test_manager.py
+++ b/external-deps/envs-manager/envs_manager/tests/test_manager.py
@@ -22,17 +22,16 @@ ENV_FILES = TESTS_DIR / "env_files"
 ENV_FILES_CONDA_LIKE = ENV_FILES / "conda-like-files"
 ENV_FILES_PIXI = ENV_FILES / "pixi-files"
 ENV_FILES_VENV = ENV_FILES / "venv-files"
-PIXI_EXECUTABLE = Path(os.environ.get("HOME")) / ".pixi" / "bin" / "pixi"
 
 MANAGER_BACKENDS_SETUP = [
-    ("pixi", PIXI_EXECUTABLE, None),
-    ("conda-like", os.environ.get("ENV_BACKEND_EXECUTABLE"), None),
-    ("venv", None, None),
+    ("pixi", None),
+    ("conda-like", None),
+    ("venv", None),
 ]
 
 BACKENDS = [
     (
-        ("pixi", PIXI_EXECUTABLE, None),
+        ("pixi", None),
         "python",
         ["packaging=21.0"],
         ["packaging"],
@@ -56,7 +55,7 @@ BACKENDS = [
         ],
     ),
     (
-        ("pixi", PIXI_EXECUTABLE, "test_env"),
+        ("pixi", "test_env"),
         "python",
         ["packaging=21.0"],
         ["packaging"],
@@ -80,7 +79,7 @@ BACKENDS = [
         ],
     ),
     (
-        ("venv", None, None),
+        ("venv", None),
         "pip",
         ["packaging==21.0"],
         ["packaging"],
@@ -94,7 +93,7 @@ BACKENDS = [
         [2, 1, 6, "The PyPA recommended tool for installing Python packages."],
     ),
     (
-        ("venv", None, "test_env"),
+        ("venv", "test_env"),
         "pip",
         ["packaging==21.0"],
         ["packaging"],
@@ -108,7 +107,7 @@ BACKENDS = [
         [2, 1, 6, "The PyPA recommended tool for installing Python packages."],
     ),
     (
-        ("conda-like", os.environ.get("ENV_BACKEND_EXECUTABLE"), None),
+        ("conda-like", None),
         "python",
         ["packaging=21.0"],
         ["packaging"],
@@ -126,7 +125,7 @@ BACKENDS = [
         [2, 1, 6, "General purpose programming language"],
     ),
     (
-        ("conda-like", os.environ.get("ENV_BACKEND_EXECUTABLE"), "test_env"),
+        ("conda-like", "test_env"),
         "python",
         ["packaging=21.0"],
         ["packaging"],
@@ -158,27 +157,27 @@ else:
 
 IMPORT_EXPORT_BACKENDS = [
     (
-        ("pixi", PIXI_EXECUTABLE, None),
+        ("pixi", None),
         str(ENV_FILES_PIXI / "pixi_import_env.zip"),
         str(ENV_FILES_PIXI / "pixi_export_env.zip"),
     ),
     (
-        ("pixi", PIXI_EXECUTABLE, "test_env"),
+        ("pixi", "test_env"),
         str(ENV_FILES_PIXI / "pixi_import_env.zip"),
         str(ENV_FILES_PIXI / "pixi_export_env.zip"),
     ),
     (
-        ("venv", None, None),
+        ("venv", None),
         str(ENV_FILES_VENV / "venv_import_env.txt"),
         str(ENV_FILES_VENV / "venv_export_env.txt"),
     ),
     (
-        ("venv", None, "test_env"),
+        ("venv", "test_env"),
         str(ENV_FILES_VENV / "venv_import_env.txt"),
         str(ENV_FILES_VENV / "venv_export_env.txt"),
     ),
     (
-        ("conda-like", os.environ.get("ENV_BACKEND_EXECUTABLE"), None),
+        ("conda-like", None),
         str(
             ENV_FILES_CONDA_LIKE / f"{BASE_IMPORT_EXPORT_FILENAME}_conda_import_env.yml"
         ),
@@ -187,7 +186,7 @@ IMPORT_EXPORT_BACKENDS = [
         ),
     ),
     (
-        ("conda-like", os.environ.get("ENV_BACKEND_EXECUTABLE"), "test_env"),
+        ("conda-like", "test_env"),
         str(
             ENV_FILES_CONDA_LIKE / f"{BASE_IMPORT_EXPORT_FILENAME}_conda_import_env.yml"
         ),
@@ -235,7 +234,8 @@ def check_packages(manager_instance, package, version):
 
 @pytest.fixture
 def manager_instance(request, tmp_path):
-    backend, executable, env_name = request.param
+    backend, env_name = request.param
+
     if not env_name:
         # Passing full env directory
         root_path = None
@@ -251,7 +251,6 @@ def manager_instance(request, tmp_path):
         root_path=root_path,
         env_name=env_name,
         env_directory=env_directory,
-        external_executable=executable,
     )
     yield manager_instance
 
@@ -420,12 +419,9 @@ def test_manager_backends(
 def test_manager_backends_import_export(
     manager_instance, initial_import_path, expected_export_path, tmp_path, capsys
 ):
-    # This test fails on Mac when using conda. It seems that's due to an error in conda
-    # because it passes with micromamba.
-    if (
-        sys.platform == "darwin"
-        and "conda" in os.environ.get("ENV_BACKEND_EXECUTABLE")
-        and isinstance(manager_instance.backend_instance, CondaLikeInterface)
+    # This test fails on Mac when using micromamba.
+    if sys.platform == "darwin" and isinstance(
+        manager_instance.backend_instance, CondaLikeInterface
     ):
         return
 

--- a/spyder_env_manager/spyder/config.py
+++ b/spyder_env_manager/spyder/config.py
@@ -9,25 +9,7 @@
 """Spyder Env Manager default configuration."""
 
 # Third-party imports
-from envs_manager.manager import (
-    DEFAULT_BACKENDS_ROOT_PATH,
-    EXTERNAL_EXECUTABLE,
-)
-
-# Spyder and local imports
-from spyder.utils.conda import find_pixi
-
-
-def pixi_executable():
-    """
-    Get default value for pixi executable.
-
-    This is the path for Pixi executable file.
-    """
-    pixi_executable = EXTERNAL_EXECUTABLE
-    if not pixi_executable:
-        pixi_executable = find_pixi()
-    return pixi_executable
+from envs_manager.manager import DEFAULT_BACKENDS_ROOT_PATH
 
 
 CONF_SECTION = "spyder_env_manager"
@@ -35,7 +17,6 @@ CONF_DEFAULTS = [
     (
         CONF_SECTION,
         {
-            "pixi_file_executable_path": pixi_executable(),
             "environments_path": str(DEFAULT_BACKENDS_ROOT_PATH),
             "selected_environment": "",
             "exclude_dependency_action": True,

--- a/spyder_env_manager/spyder/confpage.py
+++ b/spyder_env_manager/spyder/confpage.py
@@ -25,14 +25,6 @@ class SpyderEnvManagerConfigPage(PluginConfigPage):
     # ------------------------------------------------------------------------
     def setup_page(self):
         paths_group = QGroupBox(_("Paths"))
-        pixi_path_label = QLabel(_("Pixi executable:"))
-        pixi_path_label.setToolTip(_("Path to the Pixi executable"))
-        pixi_path_label.setWordWrap(True)
-
-        pixi_path = QLabel(self.get_option("pixi_file_executable_path", None))
-        pixi_path.setTextInteractionFlags(Qt.TextSelectableByMouse)
-        pixi_path.setWordWrap(True)
-
         environments_path_label = QLabel(_("Root directory for environments location:"))
         environments_path_label.setToolTip(
             _(
@@ -47,8 +39,6 @@ class SpyderEnvManagerConfigPage(PluginConfigPage):
         environments_path.setWordWrap(True)
 
         paths_layout = QVBoxLayout()
-        paths_layout.addWidget(pixi_path_label)
-        paths_layout.addWidget(pixi_path)
         paths_layout.addWidget(environments_path_label)
         paths_layout.addWidget(environments_path)
         paths_group.setLayout(paths_layout)

--- a/spyder_env_manager/spyder/plugin.py
+++ b/spyder_env_manager/spyder/plugin.py
@@ -8,9 +8,6 @@
 Spyder Env Manager Plugin.
 """
 
-# Standard library imports
-from pathlib import Path
-
 # Third-party imports
 import qtawesome as qta
 from qtpy.QtCore import Signal
@@ -103,14 +100,6 @@ class SpyderEnvManager(SpyderDockablePlugin):
     @on_plugin_teardown(plugin=Plugins.MainInterpreter)
     def on_maininterpreter_teardown(self):
         self.sig_set_spyder_custom_interpreter.disconnect()
-
-    def check_compatibility(self):
-        message = ""
-        pixi_executable_path = self.get_conf("pixi_file_executable_path")
-        valid = pixi_executable_path and Path(pixi_executable_path).exists()
-        if not valid:
-            message = _("Unable to find the Pixi executable!")
-        return valid, message
 
     def on_close(self, cancellable=True):
         return True

--- a/spyder_env_manager/spyder/widgets/main_widget.py
+++ b/spyder_env_manager/spyder/widgets/main_widget.py
@@ -515,12 +515,10 @@ class SpyderEnvManagerWidget(PluginMainWidget):
         if not environment_path:
             return
 
-        external_executable = self.get_conf("pixi_file_executable_path")
         backend = PixiInterface.ID
         manager = Manager(
             backend,
             env_directory=environment_path,
-            external_executable=external_executable,
         )
 
         self.sig_set_spyder_custom_interpreter.emit(
@@ -610,7 +608,6 @@ class SpyderEnvManagerWidget(PluginMainWidget):
                     backend=manager_options["backend"],
                     root_path=manager_options["root_path"],
                     env_name=manager_options["env_name"],
-                    external_executable=manager_options["external_executable"],
                 ),
                 action=ManagerActions.InstallPackages,
                 action_options=dict(

--- a/spyder_env_manager/spyder/workers.py
+++ b/spyder_env_manager/spyder/workers.py
@@ -54,9 +54,6 @@ class EnvironmentManagerWorker(QObject, SpyderConfigurationObserver):
 
         manager_options = request["manager_options"]
         manager_options["root_path"] = self.get_conf("environments_path")
-        manager_options["external_executable"] = self.get_conf(
-            "pixi_file_executable_path"
-        )
         self.manager = Manager(**manager_options)
 
         self.manager_action = request["action"]


### PR DESCRIPTION
- That's no longer necessary because envs-manager will be in charge of downloading and installing Pixi. That way we'll have better control over how and where we install Pixi.
- Also, make some adjustments due to the changes done in envs-manager.
- Depends on https://github.com/spyder-ide/envs-manager/pull/34.